### PR TITLE
Make SOCRATES available via github artifacts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,9 @@
+The build workflow compiles the code and makes the zip file in the [Action artifacts](https://github.com/FormingWorlds/SOCRATES/actions). Any push to the master branch will trigger the workflow to compile the code
+
+How to make a release:
+
+1. Tag a version of the code, e.g. `git tag 1.0.0`
+2. Push the tag, `git push origin tag 1.0.0`
+3. The [action-gh-release action](https://github.com/softprops/action-gh-release) detects a tagged commit and makes a [release](https://github.com/FormingWorlds/SOCRATES/releases)
+4. The release contains a zip file with the compiled code
+5. Update the release notes if necessary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,11 @@ name: Compile SOCRATES
 
 on:
   push:
-    branches: [main]
+    branches: 
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   install:
@@ -37,4 +41,4 @@ jobs:
       #   uses: softprops/action-gh-release@v1
       #   if: startsWith(github.ref, 'refs/tags/')
       #   with:
-      #     files: tetgen-${{ runner.os }}.zip
+      #     files: socrates-${{ runner.os }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,25 @@ jobs:
           sudo apt update 
           sudo apt-get install libnetcdff-dev netcdf-bin gfortran gcc
 
-      - name: SOCRATES
+      - name: Build
         run: |
           export LD_LIBRARY_PATH=""
           ./configure
           ./build_code 
           source set_rad_env 
           
+      - name: Zip
+        run: |
+          zip -r SOCRATES-${{ runner.os }} .
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: socrates-${{ runner.os }}.zip
+          path: socrates-${{ runner.os }}.zip
+
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   with:
+      #     files: tetgen-${{ runner.os }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           
       - name: Zip
         run: |
-          zip -r SOCRATES-${{ runner.os }} .
+          zip -r socrates-${{ runner.os }} .
 
       - name: Upload binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           zip -r socrates-${{ runner.os }} .
 
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: socrates-${{ runner.os }}.zip
           path: socrates-${{ runner.os }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: 
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   install:
@@ -37,8 +34,9 @@ jobs:
           name: socrates-${{ runner.os }}.zip
           path: socrates-${{ runner.os }}.zip
 
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   with:
-      #     files: socrates-${{ runner.os }}.zip
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: socrates-${{ runner.os }}.zip
+          body_path: version


### PR DESCRIPTION
This PR zips up the build for SOCRATES and makes it available via Github artifacts.

The automated releases work like this:
- Tag a version on main branch
- Push version to repo
- The `softprops/action-gh-release` detects a tagged commit and makes a release (we should test this when this is merged)

The action will build the package anyway and make them available at the actions page: https://github.com/nichollsh/SOCRATES/actions/runs/10182560102
Only a tagged version gets released.

### TODO
- [x] Automated release
- [x] Only run on main branch / tagged release
- [x] Put version in release body